### PR TITLE
Change left justified header text to be center justified.

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -21,6 +21,7 @@ h1 {
     font-weight: 900;
     left: 50%;
     position: absolute;
+    text-align: center;
     top: 50%;
     transform: translate(-50%, -50%);
 }
@@ -40,6 +41,6 @@ h1 {
 
 @media (max-device-width: 480px) {
     h1 {
-        font-size: 2.3rem;
+        font-size: 3rem;
     }
 }


### PR DESCRIPTION
Header text was left-justified when there was a line break (on mobile). I changed the css so that it is now centered all the time.